### PR TITLE
Strict config option; match exception type to access pattern

### DIFF
--- a/pypiper/AttributeDict.py
+++ b/pypiper/AttributeDict.py
@@ -38,7 +38,8 @@ class AttributeDict(object):
 		Provides dict-style access to attributes
 		"""
 		try:
-			return getattr(self, key)
+			# Invoke overridden method directly to not prohibit numeric key.
+			return self.__getattr__(key)
 		except AttributeError:
 			raise KeyError(key)
 
@@ -46,9 +47,9 @@ class AttributeDict(object):
 		return str(self.__dict__)
 
 	def __getattr__(self, name):
-		if name in self.__dict__.keys():
-			return self.name
-		else:
+		try:
+			return self.__dict__[name]
+		except KeyError:
 			if self.return_defaults:
 				# If this object has default mode on, then we should
 				# simply return the name of the requested attribute as

--- a/pypiper/AttributeDict.py
+++ b/pypiper/AttributeDict.py
@@ -37,7 +37,10 @@ class AttributeDict(object):
 		"""
 		Provides dict-style access to attributes
 		"""
-		return getattr(self, key)
+		try:
+			return getattr(self, key)
+		except AttributeError:
+			raise KeyError(key)
 
 	def __repr__(self):
 		return str(self.__dict__)

--- a/pypiper/pypiper.py
+++ b/pypiper/pypiper.py
@@ -47,12 +47,16 @@ class PipelineManager(object):
 	:param str mem: amount of memory to use, in Mb
 	:param str config_file: path to pipeline configuration file, optional
 	:param str output_parent: path to folder in which output folder will live
+	:param bool strict_config: require that key/attribute requests on this
+		PipelineManager's config section be present rather than returning the
+		requested key/attribute if it's not there (i.e., raise an exception)
 	"""
 	def __init__(
 		self, name, outfolder, version=None, args=None, multi=False,
 		manual_clean=False, recover=False, fresh=False, force_follow=False,
 		cores=1, mem="1000",
 		config_file=None, output_parent=None,
+		strict_config = False
 	):
 		# Params defines the set of options that could be updated via
 		# command line args to a pipeline run, that can be forwarded
@@ -191,7 +195,7 @@ class PipelineManager(object):
 				args.config_file = config_to_load
 				import yaml
 				config = yaml.load(config_file)
-				self.config = AttributeDict(config, default=True)
+				self.config = AttributeDict(config, default=not strict_config)
 		else:
 			self.config = None
 


### PR DESCRIPTION
Maybe eventually `pypiper` can leverage the `AttributeDict` currently in `looper.models`; for now, this is a simple patch to match/use some of its behavior.